### PR TITLE
[S5] 돌 게임

### DIFF
--- a/dynamic_programming/9655.cpp
+++ b/dynamic_programming/9655.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+using namespace std;
+
+int main(){
+    int n;
+    cin >> n;
+
+    if (n%2==0) cout << "CY" << '\n';
+    else cout << "SK" << '\n';
+}


### PR DESCRIPTION
DP 문제로 구분되지만 짝수인지 홀수인지에 따라 이긴 사람을 나눌 수 있는 문제였기 때문에 인풋의 홀짝만 구분함